### PR TITLE
Minio tenant user

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: core
 description: Core backend application for DigitalHub.
 type: application
-version: 0.1.28
+version: 0.1.29
 appVersion: "0.5.0-beta1"
 maintainers:
   - name: ffais

--- a/charts/core/templates/deployment.yaml
+++ b/charts/core/templates/deployment.yaml
@@ -50,23 +50,23 @@ spec:
             - name: DH_S3_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: minio
-                  key: rootUser
+                  name: minio-tenant
+                  key: tenantUser
             - name: DH_S3_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: minio
-                  key: rootPassword
+                  name: minio-tenant
+                  key: tenantPassword
             - name: DH_AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: minio
-                  key: rootUser
+                  name: minio-tenant
+                  key: tenantUser
             - name: DH_AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: minio
-                  key: rootPassword
+                  name: minio-tenant
+                  key: tenantPassword
             - name: DH_POSTGRES_USER
               valueFrom:
                 secretKeyRef:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -51,8 +51,6 @@ securityContext:
   # runAsUser: 1000
 
 minio:
-  rootUser: minio
-  rootPassword: minio123
   endpoint: "minio"
   endpointPort: "9000"
   bucket: "mlrun"

--- a/charts/mlrun-ce/Chart.yaml
+++ b/charts/mlrun-ce/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.6.3-dh-v0.3.11
+version: 0.6.3-dh-v0.3.12
 name: mlrun-ce
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/charts/mlrun-ce/templates/NOTES.txt
+++ b/charts/mlrun-ce/templates/NOTES.txt
@@ -24,8 +24,8 @@ You're up and running !
   http://{{ .Values.global.externalHostAddress }}:{{ .Values.minio.consoleService.nodePort }}
 
   Credentials:
-    username: {{ .Values.minio.rootUser }}
-    password: {{ .Values.minio.rootPassword }}
+    username: {{ include "mlrun-ce.minio.tenantUser" . }}
+    password: {{ include "mlrun-ce.minio.tenantPassword" . }}
 
 {{- end }}
 

--- a/charts/mlrun-ce/templates/_helpers.tpl
+++ b/charts/mlrun-ce/templates/_helpers.tpl
@@ -126,17 +126,17 @@ http://minio.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.minio.service
 {{- end -}}
 {{- end -}}
 
-{{- define "mlrun-ce.minio.rootUser" -}}
+{{- define "mlrun-ce.minio.tenantUser" -}}
 {{- if and (.Values.global.minio) (not .Values.minio.enabled) -}}
-{{ .Values.global.minio.rootUser }}
+{{ .Values.global.minio.tenantUser }}
 {{- else -}}
 {{ .Values.minio.rootUser }}
 {{- end -}}
 {{- end -}}
 
-{{- define "mlrun-ce.minio.rootPassword" -}}
+{{- define "mlrun-ce.minio.tenantPassword" -}}
 {{- if and (.Values.global.minio) (not .Values.minio.enabled) -}}
-{{ .Values.global.minio.rootPassword }}
+{{ .Values.global.minio.tenantPassword }}
 {{- else -}}
 {{ .Values.minio.rootPassword }}
 {{- end -}}

--- a/charts/mlrun-ce/templates/config/jupyter-env-configmap.yaml
+++ b/charts/mlrun-ce/templates/config/jupyter-env-configmap.yaml
@@ -5,6 +5,6 @@ metadata:
   name: jupyter-common-env
 data:
   S3_ENDPOINT_URL: {{ include "mlrun-ce.minio.service.url" . }}
-  AWS_SECRET_ACCESS_KEY: {{ .Values.minio.rootPassword }}
-  AWS_ACCESS_KEY_ID: {{ .Values.minio.rootUser }}
+  AWS_SECRET_ACCESS_KEY: {{ include "mlrun-ce.minio.tenantPassword" . }}
+  AWS_ACCESS_KEY_ID: {{ include "mlrun-ce.minio.tenantUser" . }}
 {{- end}}

--- a/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
+++ b/charts/mlrun-ce/templates/config/mlrun-env-configmap.yaml
@@ -5,11 +5,11 @@ metadata:
   name: mlrun-common-env
 data:
   MLRUN_STORAGE__AUTO_MOUNT_TYPE: s3
-  MLRUN_STORAGE__AUTO_MOUNT_PARAMS: "aws_access_key={{ include "mlrun-ce.minio.rootUser" . }},aws_secret_key={{ include "mlrun-ce.minio.rootPassword" . }},endpoint_url={{ include "mlrun-ce.minio.service.url" . }}"
+  MLRUN_STORAGE__AUTO_MOUNT_PARAMS: "aws_access_key={{ include "mlrun-ce.minio.tenantUser" . }},aws_secret_key={{ include "mlrun-ce.minio.tenantPassword" . }},endpoint_url={{ include "mlrun-ce.minio.service.url" . }}"
   MLRUN_HTTPDB__PROJECTS__FOLLOWERS: nuclio
   S3_ENDPOINT_URL: {{ include "mlrun-ce.minio.service.url" . }}
-  AWS_SECRET_ACCESS_KEY: {{ include "mlrun-ce.minio.rootPassword" . }}
-  AWS_ACCESS_KEY_ID: {{ include "mlrun-ce.minio.rootUser" . }}
+  AWS_SECRET_ACCESS_KEY: {{ include "mlrun-ce.minio.tenantPassword" . }}
+  AWS_ACCESS_KEY_ID: {{ include "mlrun-ce.minio.tenantUser" . }}
   MLRUN_HTTPDB__REAL_PATH: s3://
   MLRUN_ARTIFACT_PATH: s3://{{ include "mlrun-ce.minio.bucket" . }}/projects/{{ `{{run.project}}` }}/artifacts
   MLRUN_FEATURE_STORE__DATA_PREFIXES__DEFAULT: s3://{{ include "mlrun-ce.minio.bucket" . }}/projects/{project}/FeatureStore/{name}/{kind}
@@ -23,5 +23,4 @@ data:
   MLRUN_MODEL_ENDPOINT_MONITORING__ENDPOINT_STORE_CONNECTION: "{{ template "mlrun-ce.mlrun.modelMonitoring.DSN" . }}"
 {{- end }}
   MLRUN_GRAFANA_URL: http://{{ .Values.global.externalHostAddress }}:{{ index .Values "kube-prometheus-stack" "grafana" "service" "nodePort" }}
-  MLRUN_httpdb__nuclio__default_service_type: {{ .Values.pipelines.ui.service.type }}
 {{- end}}

--- a/charts/mlrun-ce/values.yaml
+++ b/charts/mlrun-ce/values.yaml
@@ -12,8 +12,8 @@ global:
   crd:
     enabled: true
   minio:
-    rootUser: minio
-    rootPassword: minio123
+    tenantUser: datalake
+    tenantPassword: datalake
     endpoint: "minio"
     endpointPort: "9000"
     bucket: "mlrun"


### PR DESCRIPTION
Core now gets the values of the new minio users. Unused values for minio have been deleted.
MlRun-ce now uses two helpers functions to get the credentials of the new minio user.
Env variable in mlrun common env config map has been deleted, now the invoke function in the tutorial works.