### PR TITLE
feat(digitalhub): dremio now uses coder email and an automatically generated password; core tests now take the token from core directly; kubeflow-pipelines now uses a separate bucket 

### DIFF
--- a/charts/digitalhub/Chart.yaml
+++ b/charts/digitalhub/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
     url: https://github.com/ffais
   - name: calcagiara
     url: https://github.com/Calcagiara
-version: "0.8.0-beta2"
+version: "0.8.0-beta3"
 appVersion: "0.8.0"
 dependencies:
 - name: apigw-operator

--- a/charts/digitalhub/confs/dremio/add_source_with_api.sh
+++ b/charts/digitalhub/confs/dremio/add_source_with_api.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-TOKEN=$(curl -s -X POST "http://${DREMIO_URL}:9047/apiv2/login" --header 'Content-Type: application/json' --data-raw "{\"userName\": \"admin\",\"password\": \"${ADMIN_PASSWORD}\"}" | jq -r .token)
+TOKEN=$(curl -s -X POST "http://${DREMIO_URL}:9047/apiv2/login" --header 'Content-Type: application/json' --data-raw "{\"userName\": \"${DREMIO_CODER_EMAIL}\",\"password\": \"${ADMIN_PASSWORD}\"}" | jq -r .token)
 
 echo "add postgres"
 curl -v -s -X POST "http://${DREMIO_URL}:9047/api/v3/catalog" \

--- a/charts/digitalhub/confs/dremio/init-data.sh
+++ b/charts/digitalhub/confs/dremio/init-data.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
-DIR="/opt/dremio/data/db"
-if [ -d "$DIR" ]; then
-    echo "directory already exist"
-    exit 0
-else
-    mkdir -p /opt/dremio/data/db
-    tar xvf /tmp/init/dremio-backup.tar --directory /tmp
-    /opt/dremio/bin/dremio-admin restore -d /tmp/dremio_backup_2023-07-06_12.02/
-    echo "$ADMIN_PASSWORD"
-    /opt/dremio/bin/dremio-admin set-password -u admin -p "$ADMIN_PASSWORD"
-fi
+
+curl "http://${DREMIO_URL}:9047/apiv2/bootstrap/firstuser" -X PUT \
+      -H 'Authorization: _dremionull' -H 'Content-Type: application/json' \
+      -d '{
+         "userName": "'"$DREMIO_CODER_EMAIL"'",
+         "password": "'"$ADMIN_PASSWORD"'",
+         "firstName": "digitalhub",
+         "lastName": "digitalhub",
+         "email": "'"$DREMIO_CODER_EMAIL"'"
+       }'

--- a/charts/digitalhub/confs/tests/python-test/python-test-container.py
+++ b/charts/digitalhub/confs/tests/python-test/python-test-container.py
@@ -40,7 +40,7 @@ def main():
         scope = 'tenant1-core'
         client = BackendApplicationClient(client_id=client_id)
         oauth = OAuth2Session(client=client, scope=scope)
-        token = oauth.fetch_token(token_url='https://aac.digitalhub-dev.smartcommunitylab.it/oauth/token', client_id=client_id, client_secret=client_secret, scope=scope)
+        token = oauth.fetch_token(token_url='https://core.tenant1.digitalhub-dev.smartcommunitylab.it/auth/token', client_id=client_id, client_secret=client_secret, scope=scope)
         os.environ["DHCORE_ACCESS_TOKEN"] = token["access_token"]
     
     # Get or create project

--- a/charts/digitalhub/confs/tests/python-test/python-test-dbt.py
+++ b/charts/digitalhub/confs/tests/python-test/python-test-dbt.py
@@ -40,7 +40,7 @@ def main():
         scope = 'tenant1-core'
         client = BackendApplicationClient(client_id=client_id)
         oauth = OAuth2Session(client=client, scope=scope)
-        token = oauth.fetch_token(token_url='https://aac.digitalhub-dev.smartcommunitylab.it/oauth/token', client_id=client_id, client_secret=client_secret, scope=scope)
+        token = oauth.fetch_token(token_url='https://core.tenant1.digitalhub-dev.smartcommunitylab.it/auth/token', client_id=client_id, client_secret=client_secret, scope=scope)
         os.environ["DHCORE_ACCESS_TOKEN"] = token["access_token"]
 
     # Get or create project

--- a/charts/digitalhub/templates/tests/python-test.yaml
+++ b/charts/digitalhub/templates/tests/python-test.yaml
@@ -36,13 +36,13 @@ spec:
             - name: "CORE_CLIENT_ID"
               valueFrom:
                 secretKeyRef:
-                  name: "aac-digitalhub-tenant1-core-secret"
-                  key: "clientid"
+                  name: "core-auth-creds"
+                  key: "clientId"
             - name: "CORE_CLIENT_SECRET"
               valueFrom:
                 secretKeyRef:
-                  name: "aac-digitalhub-tenant1-core-secret"
-                  key: "clientsecret"
+                  name: "core-auth-creds"
+                  key: "clientSecret"
             {{- if $.Values.core.ingress.enabled }}
             {{- with (index $.Values.core.ingress.hosts 0) }}
             - name: "DHCORE_ENDPOINT"

--- a/charts/digitalhub/values.yaml
+++ b/charts/digitalhub/values.yaml
@@ -28,9 +28,12 @@ global:
     digitalhubUserSecret: digitalhub-minio-creds
     digitalhubUser: &digitalhubUser digitalhub
     digitalhubPassword: &digitalhubPassword digitalhub
+    kfpUser: &kfpUser kfp
+    kfpPassword: &kfpPassword kfpwd123
     endpoint: &minioEndpoint "minio"
     endpointPort: &minioEndpointPort "9000"
     bucket: &minioBucket "datalake"
+    kfpBucket: &kfpBucket "kfp"
     protocol: &minioProtocol "http"
   solr:
     fullNameOverride: &solrFullNameOverride digitalhub
@@ -434,6 +437,9 @@ minio:
     - name: datalake
       policy: none
       purge: false
+    - name: kfp
+      policy: none
+      purge: false
   resources:
     requests:
       memory: 0.5Gi
@@ -468,12 +474,22 @@ minio:
     - accessKey: *digitalhubUser
       secretKey: *digitalhubPassword
       policy: readwritedigitalhub
+    - accessKey: *kfpUser
+      secretKey: *kfpPassword
+      policy: readwritekfp
   policies:
     - name: readwritedigitalhub
       statements:
         - effect: Allow
           resources:
             - 'arn:aws:s3:::datalake/*'
+          actions:
+            - "s3:*"
+    - name: readwritekfp
+      statements:
+        - effect: Allow
+          resources:
+            - 'arn:aws:s3:::kfp/*'
           actions:
             - "s3:*"
 
@@ -526,9 +542,9 @@ kubeflow-pipelines:
       nodePort: 30100
   s3:
     enabled: true
-    accessKey: *digitalhubUser
-    secretKey: *digitalhubPassword
+    accessKey: *kfpUser
+    secretKey: *kfpPassword
     endpoint: *minioEndpoint
     endpointPort: *minioEndpointPort
-    bucket: *minioBucket
+    bucket: *kfpBucket
     protocol: *minioProtocol


### PR DESCRIPTION
In this release:

- Dremio now takes the Coder user's email and sets it as the username for logging in. The password is now randomly generated, ensuring that it matches the creteria for a Dremio password. You can now see both username and password when you create the workspace.
- Tests for Core have been updated; now, the token request will be sent to Core itself.
- Kubeflow-Pipelines do not use the bucket datalake anymore; instead, a new bucket called kfp has been created to separated the stored artifacts