### PR TITLE
Feature: add client credentials flow support to KRM

### DIFF
--- a/charts/kubernetes-resource-manager/templates/deployment.yaml
+++ b/charts/kubernetes-resource-manager/templates/deployment.yaml
@@ -53,14 +53,39 @@ spec:
           {{- if .Values.oidc.enabled }}
           env:
             - name: KRM_AUTH_OAUTH2_AUDIENCE
-              {{- if .Values.oidc.audience.externalSecret.name  }}
+              {{- if .Values.oidc.audience.externalSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oidc.audience.externalSecret.name }}
+                  key: {{ .Values.oidc.audience.externalSecret.key }}
+              {{- else if .Values.oidc.audience.plain }}
+              value: "{{ .Values.oidc.audience.plain }}"     
+              {{- else if .Values.oidc.audience.clientId }}
+              value: "{{ .Values.oidc.audience.clientId }}"              
+              {{- else if .Values.oidc.client.externalSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oidc.client.externalSecret.name }}
+                  key: {{ .Values.oidc.client.externalSecret.key }}
+              {{- else }}
+              value: "{{ .Values.oidc.client.clientId }}"
+              {{- end }}           
+            - name: KRM_AUTH_OAUTH2_CLIENT_ID
+              {{- if .Values.oidc.client.externalSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oidc.client.externalSecret.name }}
+                  key: {{ .Values.oidc.client.externalSecret.key }}
+              {{- else if .Values.oidc.client.clientId }}
+              value: "{{ .Values.oidc.client.clientId }}"              
+              {{- else if .Values.oidc.audience.externalSecret.name }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.oidc.audience.externalSecret.name }}
                   key: {{ .Values.oidc.audience.externalSecret.key }}
               {{- else }}
-              value: {{ .Values.oidc.audience.clientId }}
-              {{- end }}
+              value: "{{ .Values.oidc.audience.clientId }}"
+              {{- end }}    
           {{- end }}
           envFrom:
           - configMapRef:


### PR DESCRIPTION
Updated Helm chart to add KRM_AUTH_OAUTH2_CLIENT_ID environment variable while preserving backward compatibility.

KRM_AUTH_OAUTH2_AUDIENCE continues to support existing values.yaml configurations.

The new CLIENT_ID allows distinguishing the OAuth2 client identifier from the audience, enabling the client credentials flow.

Conditional logic ensures both plain values and external secrets are supported for old and new properties.